### PR TITLE
increase feed front size

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2723,7 +2723,7 @@ bs-dropdown-container {
 .feed-post__content {
   font-style: normal;
   font-weight: normal;
-  font-size: 15px;
+  font-size: 18px;
   line-height: 24px;
   margin-top: 8px;
   overflow-wrap: anywhere;


### PR DESCRIPTION
Found that the feed font size at 15px was just not working well.

Here making it 18 which is in line with what you are using in the post textbox

im sure 17 is fine too/

![20211014-w2OL99OK](https://user-images.githubusercontent.com/69529928/137375918-9d5a4b78-3db1-4e75-9fa9-8f29f76dd299.png)

See feedback here from community:

https://diamondapp.com/posts/7de6dad5a6158b244d7dce699e4ebdd525c4862d93f6ca442e3e1b6e887c2b22?tab=posts
