### PR TITLE
Add tools for adding user level multipliers to the hot feed.

### DIFF
--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -113,7 +113,7 @@
       Update the hot feed algorithm by updating the values below.
     </div>
 
-    <!-- Update Global Params (Super Admin Only) -->
+    <!-- Update HotFeed Interaction Cap (Super Admin Only) -->
     <div class="fs-15px font-weight-bold mt-15px mb-5px px-15px">
       Update Interaction Cap (max $DESO locked)
       <div class="d-flex align-items-center justify-content-between font-weight-normal mt-5px">
@@ -129,7 +129,6 @@
           (click)="updateHotFeedInteractionCap()"
           class="btn btn-outline-primary fs-15px ml-5px"
           style="width: fit-content"
-          [ngStyle]="{ disabled: updatingGlobalParams }"
         >
           Update
         </button>
@@ -142,7 +141,7 @@
       </div>
     </div>
 
-    <!-- Update Global Params (Super Admin Only) -->
+    <!-- Update HotFeed Time Decay Blocks (Super Admin Only) -->
     <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
       Update Time Decay Blocks
       <div class="d-flex align-items-center justify-content-between font-weight-normal mt-5px">
@@ -158,7 +157,6 @@
           (click)="updateHotFeedTimeDecayBlocks()"
           class="btn btn-outline-primary fs-15px ml-5px"
           style="width: fit-content"
-          [ngStyle]="{ disabled: updatingGlobalParams }"
         >
           Update
         </button>
@@ -169,6 +167,100 @@
           Updating...
         </button>
       </div>
+    </div>
+
+    <!-- Update HotFeed User Posts Multiplier (Super Admin Only) -->
+    <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
+      Update User Posts Multiplier <span class="font-weight-normal">(boost all of a user's posts)</span>
+      <div class="d-flex align-items-center justify-content-between font-weight-normal mt-5px">
+        <input
+          [(ngModel)]="hotFeedUserForPostsMultiplier"
+          class="form-control fs-15px lh-15px w-100"
+          placeholder="Username"
+        />
+        <input
+          [(ngModel)]="hotFeedUserPostsMultiplier"
+          type="number"
+          class="form-control fs-15px lh-15px w-100 ml-5px"
+          placeholder="Posts Multiplier"
+        />
+        <button
+          *ngIf="!updatingHotFeedUserPostsMultiplier"
+          (click)="updateHotFeedUserPostsMultiplier()"
+          class="btn btn-outline-primary fs-15px ml-5px"
+          style="width: fit-content"
+        >
+          Update
+        </button>
+        <button
+          *ngIf="updatingHotFeedUserPostsMultiplier"
+          class="btn btn-dark fs-15px ml-5px"
+          style="width: fit-content" disabled>
+          Updating...
+        </button>
+      </div>
+    </div>
+
+    <!-- Update HotFeed User Interaction Multiplier (Super Admin Only) -->
+    <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
+      Update User Interaction Multiplier <span class="font-weight-normal">(boost all of a user's interactions)</span>
+      <div class="d-flex align-items-center justify-content-between font-weight-normal mt-5px">
+        <input
+          [(ngModel)]="hotFeedUserForInteractionMultiplier"
+          class="form-control fs-15px lh-15px w-100"
+          placeholder="Username"
+        />
+        <input
+          [(ngModel)]="hotFeedUserInteractionMultiplier"
+          type="number"
+          class="form-control fs-15px lh-15px w-100 ml-5px"
+          placeholder="Interaction Multiplier"
+        />
+        <button
+          *ngIf="!updatingHotFeedUserInteractionMultiplier"
+          (click)="updateHotFeedUserInteractionMultiplier()"
+          class="btn btn-outline-primary fs-15px ml-5px"
+          style="width: fit-content"
+        >
+          Update
+        </button>
+        <button
+          *ngIf="updatingHotFeedUserInteractionMultiplier"
+          class="btn btn-dark fs-15px ml-5px"
+          style="width: fit-content" disabled>
+          Updating...
+        </button>
+      </div>
+    </div>
+
+    <!-- Look Up HotFeed User Multipliers (Super Admin Only) -->
+    <div class="fs-15px font-weight-bold mt-15px mb-15px px-15px">
+      <i class="fa fa-search"></i>&nbsp;
+      Look Up User Interaction Multipliers
+      <div class="d-flex align-items-center justify-content-between font-weight-normal mt-5px">
+        <input
+          [(ngModel)]="hotFeedUserForSearch"
+          class="form-control fs-15px lh-15px w-100"
+          placeholder="Username"
+        />
+        <button
+          *ngIf="!searchingHotFeedUserMultipliers"
+          (click)="searchForHotFeedUserMultipliers()"
+          class="btn btn-outline-primary fs-15px ml-5px"
+          style="width: fit-content"
+        >
+          Search
+        </button>
+        <button
+          *ngIf="searchingHotFeedUserMultipliers"
+          class="btn btn-dark fs-15px ml-5px"
+          style="width: fit-content" disabled>
+          Searching...
+        </button>
+      </div>
+    </div>
+    <div *ngIf="hotFeedUserSearchResults" class="px-15px pb-15px" style="white-space: pre">
+      {{ hotFeedUserSearchResults }}
     </div>
 
     <div class="

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -150,14 +150,24 @@ export class AdminComponent implements OnInit {
   getUserAdminDataPublicKey = "";
   getUserAdminDataResponse = null;
 
+  // Hot feed.
   hotFeedPosts = [];
   hotFeedPostHashes = [];
   loadingHotFeed = false;
   loadingMoreHotFeed = false;
   hotFeedInteractionCap = 0;
   hotFeedTimeDecayBlocks = 0;
+  hotFeedUserForInteractionMultiplier: string;
+  hotFeedUserInteractionMultiplier: number;
+  hotFeedUserForPostsMultiplier: string;
+  hotFeedUserPostsMultiplier: number;
   updatingHotFeedInteractionCap = false;
   updatingHotFeedTimeDecayBlocks = false;
+  updatingHotFeedUserInteractionMultiplier = false;
+  updatingHotFeedUserPostsMultiplier = false;
+  searchingHotFeedUserMultipliers = false;
+  hotFeedUserForSearch: string;
+  hotFeedUserSearchResults;
 
   constructor(
     private _globalVars: GlobalVarsService,
@@ -386,6 +396,68 @@ export class AdminComponent implements OnInit {
             "Error updating hot TimeDecayBlocks: " + this.backendApi.stringifyError(err));
         }
       ).add(() => { this.updatingHotFeedTimeDecayBlocks = false; });
+  }
+
+  updateHotFeedUserPostsMultiplier() {
+    this.updatingHotFeedUserPostsMultiplier = true;
+    this.backendApi
+      .AdminUpdateHotFeedUserMultiplier(
+        this.globalVars.localNode,
+        this.globalVars.loggedInUser.PublicKeyBase58Check,
+        this.hotFeedUserForPostsMultiplier,
+        -1, /*InteractionMultiplier -- negative values are ignored*/
+        this.hotFeedUserPostsMultiplier,
+      ).subscribe(
+        (res) => {
+          this.globalVars._alertSuccess("Successfully updated posts multiplier.")
+        },
+        (err) => {
+          console.error(err);
+          this.globalVars._alertError(
+            "Error updating posts multiplier: " + this.backendApi.stringifyError(err));
+        }
+      ).add(() => { this.updatingHotFeedUserPostsMultiplier = false; });
+  }
+
+  updateHotFeedUserInteractionMultiplier() {
+    this.updatingHotFeedUserInteractionMultiplier = true;
+    this.backendApi
+      .AdminUpdateHotFeedUserMultiplier(
+        this.globalVars.localNode,
+        this.globalVars.loggedInUser.PublicKeyBase58Check,
+        this.hotFeedUserForInteractionMultiplier,
+        this.hotFeedUserInteractionMultiplier,
+        -1, /*PostsMultiplier -- negative values are ignored*/
+      ).subscribe(
+        (res) => {
+          this.globalVars._alertSuccess("Successfully updated interaction multiplier.")
+        },
+        (err) => {
+          console.error(err);
+          this.globalVars._alertError(
+            "Error updating interaction multiplier: " + this.backendApi.stringifyError(err));
+        }
+      ).add(() => { this.updatingHotFeedUserInteractionMultiplier = false; });
+  }
+
+  searchForHotFeedUserMultipliers() {
+    this.searchingHotFeedUserMultipliers = true;
+    this.backendApi
+      .AdminGetHotFeedUserMultiplier(
+        this.globalVars.localNode,
+        this.globalVars.loggedInUser.PublicKeyBase58Check,
+        this.hotFeedUserForSearch,
+      ).subscribe(
+        (res) => { this.hotFeedUserSearchResults = JSON.stringify({
+          "InteractionMultiplier": res.InteractionMultiplier,
+          "PostsMultiplier": res.PostsMultiplier,
+        }, null, 4)},
+        (err) => {
+          console.error(err);
+          this.globalVars._alertError(
+            "Error fetching user's multipliers: " + this.backendApi.stringifyError(err));
+        }
+      ).add(() => { this.searchingHotFeedUserMultipliers = false; });
   }
 
   _loadPosts() {

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -124,6 +124,8 @@ export class BackendRoutes {
   static RoutePathAdminGetHotFeedAlgorithm = "/api/v0/admin/get-hot-feed-algorithm";
   static RoutePathAdminUpdateHotFeedAlgorithm = "/api/v0/admin/update-hot-feed-algorithm";
   static RoutePathAdminUpdateHotFeedPostMultiplier = "/api/v0/admin/update-hot-feed-post-multiplier";
+  static RoutePathAdminUpdateHotFeedUserMultiplier = "/api/v0/admin/update-hot-feed-user-multiplier";
+  static RoutePathAdminGetHotFeedUserMultiplier = "/api/v0/admin/get-hot-feed-user-multiplier";
 
   // Referral program admin routes.
   static RoutePathAdminCreateReferralHash = "/api/v0/admin/create-referral-hash";
@@ -2033,6 +2035,32 @@ export class BackendApiService {
       AdminPublicKey,
       PostHashHex,
       Multiplier,
+    });
+  }
+
+  AdminUpdateHotFeedUserMultiplier(
+    endpoint: string,
+    AdminPublicKey: string,
+    Username: string,
+    InteractionMultiplier: number,
+    PostsMultiplier: number,
+  ): Observable<any> {
+    return this.jwtPost(endpoint, BackendRoutes.RoutePathAdminUpdateHotFeedUserMultiplier, AdminPublicKey, {
+      AdminPublicKey,
+      Username,
+      InteractionMultiplier,
+      PostsMultiplier,
+    });
+  }
+
+  AdminGetHotFeedUserMultiplier(
+    endpoint: string,
+    AdminPublicKey: string,
+    Username: string,
+  ): Observable<any> {
+    return this.jwtPost(endpoint, BackendRoutes.RoutePathAdminGetHotFeedUserMultiplier, AdminPublicKey, {
+      AdminPublicKey,
+      Username,
     });
   }
 

--- a/src/app/feed/feed.component.html
+++ b/src/app/feed/feed.component.html
@@ -71,7 +71,7 @@
   <!-- Posts -->
   <div *ngIf="showGlobalOrFollowingOrHotPosts()">
     <div class="mobile-scroll" *ngFor="let post of postsToShow()">
-      <div *ngIf="post.ProfileEntryResponse">
+      <div *ngIf="post && post.ProfileEntryResponse">
         <!--
             The post.parentPost stuff is a hack to make it so that a new comment shows up
             in the feed with the "replying to @[parentPost.Username]" content diplayed.


### PR DESCRIPTION
Add tools for node operators to boost specific users in their feed.  This useful, for example, if someone wants to run a sports focused feed and boost the value of athlete posts and interactions in the algorithm.
![image](https://user-images.githubusercontent.com/81658108/137577300-4801c7d8-b4f9-4b6a-bb82-11f91123f3e4.png)
