### PR TITLE
disable-search-os-autocomplete

### DIFF
--- a/src/app/search-bar/search-bar.component.html
+++ b/src/app/search-bar/search-bar.component.html
@@ -33,6 +33,7 @@
         }"
         placeholder="Search..."
         id="searchbar"
+        autocomplete="off"
         #searchbar
       />
     </div>


### PR DESCRIPTION
See https://github.com/deso-protocol/frontend/pull/498#issue-1035303739

Fixes this OS autocomplete popup


![](https://user-images.githubusercontent.com/69529928/138729257-146ba038-0db7-48f2-bc90-b918a644b952.png)
