### PR TITLE
support gitpod 1 click dev environment

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,24 @@
+# Commands to start on workspace startup
+tasks:
+  - name: open terminial
+  - name: install & run dev server
+    openMode: split-right
+    init: npm install
+    command: npm start
+
+# Pre-install some extensions
+vscode:
+  extensions:
+    - angular.ng-template
+    - ecmel.vscode-html-css
+    - eamodio.gitlens
+    
+# Ports to expose on workspace startup
+ports:
+  - port: 4200
+    onOpen: open-browser
+
+# Github integration
+github:
+  prebuilds:
+    master: true

--- a/README.md
+++ b/README.md
@@ -14,3 +14,22 @@ docs should give you everything you need to get started:
 * [DeSo Code Walkthrough](https://docs.deso.org/code/walkthrough)
 * [Setting Up Your Dev Environment](https://docs.deso.org/code/dev-setup)
 * [Making Your First Changes](https://docs.deso.org/code/making-your-first-changes)
+
+# Start Coding
+
+The quickest way to contribute changes to DiamondApp is the following these steps:
+
+1. Open frontend repo in Gitpod
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/deso-protocol/frontend)
+
+You can use any repo / branch URL and just prepend `https://gitpod.io/#` to it.
+
+2. If needed, login to your github account
+
+3. Set the correct `lastLocalNodeV2`  to `"https://api.tijn.club"` in your browser Local Storage for the gitpod preview URL
+
+4. Create a new branch to start working
+
+To commit / submit a pull reqest from gitpod, you will need to give gitpod additional permissions to your github account: `public_repo, read:org, read:user, repo, user:email, workflow` which you can do on the [GitPod Integrations page](https://gitpod.io/integrations).
+


### PR DESCRIPTION
Related to this post: 
https://diamondapp.com/posts/a87e6e48f16bc01a2e5c34609c65e38a7b9ec0bec5d51c6ff7a271037eb58daa?tab=posts

This small addition adds easier gitpod support with pre-build images on the main branch so people can click a link and start developing. No need even to do `npm init && npm start`.

There is 1 addition I left out here which is to add an environment for gitpod which would also set an external `lastLocalNodeV2` automatically.

Note - gitpod is a bit slow launching this evening. Usually its instant. 
