### PR TITLE
Remove NFT information when a post is hidden

### DIFF
--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -474,7 +474,13 @@
   </div>
 
   <div
-    *ngIf="showNFTDetails && postContent.IsNFT && !(post.IsNFT && post.NumNFTCopies === post.NumNFTCopiesBurned)"
+    *ngIf="
+          showNFTDetails 
+          && postContent.IsNFT 
+          && !(post.IsNFT && post.NumNFTCopies === post.NumNFTCopiesBurned)
+          && !post.IsHidden
+          && !hidingPost
+          "
     class="fs-15px w-100 feed-post__nft-footer"
     [ngStyle]="{ 'border-radius': setBorder || cardStyle ? '0 0 12px 12px' : '' }"
     (click)="onPostClicked($event)"


### PR DESCRIPTION
When hiding a post that is minted as an NFT*, the post itself will be removed from the UI, however, the footer showing data about that NFT is still present. This should be removed for a better experience. 

* This bug occurs in a very specific situation. Of course, you aren't able to modify posts on-chain which are minted. This means that in theory, you'd never actually be able to hide an NFT, however, this isn't the case. Right now Diamond lets you hide any NFT (Although its errors, the post is still removed from state) -- but this is an unrelated bug that should also be fixed (Though, this PR will also remove the footer for those posts which get removed from state because of this bug. The best course of action here is likely removing the frontend ability to even press "Hide", but I digress). Rather, this PR fixes the case where you repost an NFT and then hide your repost. Since the report itself is not minted, you can hide it following all rules, but the footer from the reposted NFT remains. 

I should also note since this is a super simple change I didn't test prior to submitting it. This is, I know, bad practice, but I figured due to time & resource constraints I'd submit anyone in hopes someone else would be willing to test.

Happy coding!