### PR TITLE
Fixed powered by text in top diamonded list

### DIFF
--- a/src/app/right-bar-creators/right-bar-creators.component.ts
+++ b/src/app/right-bar-creators/right-bar-creators.component.ts
@@ -4,6 +4,7 @@ import { BackendApiService } from "../backend-api.service";
 import { Router } from "@angular/router";
 import { BsModalService } from "ngx-bootstrap/modal";
 import { BuyDesoModalComponent } from "../buy-deso-page/buy-deso-modal/buy-deso-modal.component";
+import { environment } from "../../environments/environment";
 
 export class RightBarTabOption {
   name: string;
@@ -38,12 +39,12 @@ export class RightBarCreatorsComponent implements OnInit {
   static GAINERS: RightBarTabOption = {
     name: "right_bar.creators.top_daily_gainers",
     width: 175,
-    poweredBy: { name: "Altumbase", link: "https://altumbase.com/tools?ref=diamondapp" },
+    poweredBy: { name: "Altumbase", link: `https://altumbase.com/tools?${environment.node.name}` },
   };
   static DIAMONDS: RightBarTabOption = {
     name: "right_bar.creators.top_daily_diamond_creators",
     width: 275,
-    poweredBy: { name: "Bitclout Pulse", link: "https://desopulse.com" },
+    poweredBy: { name: "Altumbase", link: `https://altumbase.com/tools?${environment.node.name}` },
   };
   static COMMUNITY: RightBarTabOption = {
     name: "right_bar.creators.top_community_projects",


### PR DESCRIPTION
Fixes "powered by" text in top diamonds component. 

Right now the text says "powered by Bitclout Pulse" while the data is taken from Altumbase.
<img width="383" alt="Screen Shot 2022-01-12 at 09 23 54" src="https://user-images.githubusercontent.com/7041720/149090530-9fda0c0c-1966-4c38-95ae-5e48ea01aa28.png">

This PR fixes it:
<img width="375" alt="Screen Shot 2022-01-12 at 09 24 28" src="https://user-images.githubusercontent.com/7041720/149090626-e6e2457c-e5b3-4137-ab83-3cfd574b00c0.png">

It also adds ${environment.node.name} to the link (same way as on bitclout.com).
