### PR TITLE
top dimaonded right column style fix

### DIFF
--- a/src/app/right-bar-creators/right-bar-creators-leaderboard/right-bar-creators-leaderboard.component.html
+++ b/src/app/right-bar-creators/right-bar-creators-leaderboard/right-bar-creators-leaderboard.component.html
@@ -60,7 +60,7 @@
         </div>
         <div class="fc-blue" *ngIf="activeTab === RightBarCreatorsComponent.DIAMONDS.name">
           {{ globalVars.abbreviateNumber(profileEntryResponse.DiamondsReceived, 0) }}
-          <i class="icon-diamond" style="margin-left: -10px"></i>
+          <i class="icon-diamond" style="margin-left: -5px"></i>
         </div>
         <div
           [ngClass]="{


### PR DESCRIPTION
Fixes right column top diamonds list.

Now:
<img width="373" alt="Screen Shot 2022-01-20 at 04 53 43" src="https://user-images.githubusercontent.com/7041720/150270799-a99731a9-a833-4cdb-af2b-22889174ebb8.png">

After fix:
<img width="367" alt="Screen Shot 2022-01-20 at 04 54 17" src="https://user-images.githubusercontent.com/7041720/150270777-4414244a-2430-41e4-8fbc-3b3cb62db6e9.png">

