### PR TITLE
If get user metadata throws an error, swallow it and return null

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import * as AOS from "aos";
 import { environment } from "../environments/environment";
 import { ThemeService } from "./theme/theme.service";
 import { of, Subscription, zip } from "rxjs";
+import { catchError } from "rxjs/operators";
 import { isNil } from "lodash";
 
 @Component({
@@ -118,7 +119,12 @@ export class AppComponent implements OnInit {
     return zip(
       this.backendApi.GetUsersStateless(this.globalVars.localNode, [loggedInUserPublicKey], false),
       environment.verificationEndpointHostname && !isNil(loggedInUserPublicKey)
-        ? this.backendApi.GetUserMetadata(environment.verificationEndpointHostname, loggedInUserPublicKey)
+        ? this.backendApi.GetUserMetadata(environment.verificationEndpointHostname, loggedInUserPublicKey).pipe(
+          catchError((err) => {
+            console.error(err);
+            return of(null);
+          })
+        )
         : of(null)
     ).subscribe(
       ([res, userMetadata]) => {


### PR DESCRIPTION
This is a port of https://github.com/deso-protocol/frontend/pull/556

This patch should prevent downtime when node.deso.org is down