### PR TITLE
Add env for production proxy settings

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -44,6 +44,14 @@
             ]
           },
           "configurations": {
+            "prod-proxy": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod-proxy.ts"
+                }
+              ]
+            },
             "production": {
               "fileReplacements": [
                 {
@@ -80,6 +88,9 @@
             "browserTarget": "deso-frontend:build"
           },
           "configurations": {
+            "prod-proxy": {
+              "browserTarget": "deso-frontend:build:prod-proxy"
+            },
             "production": {
               "browserTarget": "deso-frontend:build:production"
             }

--- a/src/environments/environment.prod-proxy.ts
+++ b/src/environments/environment.prod-proxy.ts
@@ -1,0 +1,28 @@
+// This file can be replaced during build by using the `fileReplacements` array.
+// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// The list of file replacements can be found in `angular.json`.
+
+export const environment = {
+  production: false,
+  uploadImageHostname: "node.deso.org",
+  verificationEndpointHostname: "node.deso.org",
+  uploadVideoHostname: "node.deso.org",
+  identityURL: "https://identity.deso.org",
+  supportEmail: "",
+  dd: {
+    apiKey: "DCEB26AC8BF47F1D7B4D87440EDCA6",
+    jsPath: "https://diamondapp.com/tags.js",
+    ajaxListenerPath: "diamondapp.com/api",
+    endpoint: "https://diamondapp.com/js/",
+  },
+  amplitude: {
+    key: "",
+    domain: "",
+  },
+  node: {
+    id: 3,
+    name: "Diamond",
+    url: "https://diamondapp.com",
+    logoAssetDir: "/assets/diamond/",
+  },
+};


### PR DESCRIPTION
Instead of modifying the code and worrying about accidentally committing a busted dev environment file, it's probably wise to just have a dedicated environment config for running a reverse proxy. Of course this is only useful if you have a local proxy server running.

This config can be add to the build by running: `ng serve -c prod-proxy`