### PR TITLE
load more thread replies when there are more to load

### DIFF
--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -570,4 +570,5 @@
       </div>
     </div>
   </div>
+  <ng-content select="[footer]"></ng-content>
 </div>

--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -570,5 +570,5 @@
       </div>
     </div>
   </div>
-  <ng-content select="[footer]"></ng-content>
+  <ng-content select="[feed-post-footer]"></ng-content>
 </div>

--- a/src/app/post-thread-page/helpers/thread-manager.ts
+++ b/src/app/post-thread-page/helpers/thread-manager.ts
@@ -186,7 +186,11 @@ export class ThreadManager {
   }
 
   addChildrenToThread(thread: Thread, subcomment: PostEntryResponse) {
-    thread.children = [...thread.children, ...flattenThread(subcomment).children];
+    thread.children = [
+      ...thread.children.slice(0, thread.children.length - 1),
+      { ...subcomment },
+      ...flattenThread(subcomment).children,
+    ];
   }
 
   /**

--- a/src/app/post-thread-page/helpers/thread-manager.ts
+++ b/src/app/post-thread-page/helpers/thread-manager.ts
@@ -185,6 +185,10 @@ export class ThreadManager {
     }
   }
 
+  addChildrenToThread(thread: Thread, subcomment: PostEntryResponse) {
+    thread.children = [...thread.children, ...flattenThread(subcomment).children];
+  }
+
   /**
    * Dumps any existing threads and busts the array cache.
    */

--- a/src/app/post-thread-page/post-thread/post-thread.component.html
+++ b/src/app/post-thread-page/post-thread/post-thread.component.html
@@ -95,7 +95,16 @@
               [blocked]="isPostBlocked(subcommentPost)"
               (postDeleted)="onSubcommentHidden(subComment, thread.children[j - 1] || thread.parent, thread)"
               (userBlocked)="afterUserBlocked($event)"
-            ></feed-post>
+            >
+              <button
+                *ngIf="j === thread.children.length - 1 && subcommentPost.CommentCount > 0"
+                class="post-thread__see-more-button"
+                (click)="loadMoreReplies(thread, subcommentPost)"
+                footer
+              >
+                {{ "post_thread.see_more" | transloco }}
+              </button>
+            </feed-post>
           </div>
         </div>
       </div>

--- a/src/app/post-thread-page/post-thread/post-thread.component.html
+++ b/src/app/post-thread-page/post-thread/post-thread.component.html
@@ -96,14 +96,19 @@
               (postDeleted)="onSubcommentHidden(subComment, thread.children[j - 1] || thread.parent, thread)"
               (userBlocked)="afterUserBlocked($event)"
             >
-              <button
-                *ngIf="j === thread.children.length - 1 && subcommentPost.CommentCount > 0"
-                class="post-thread__see-more-button"
-                (click)="loadMoreReplies(thread, subcommentPost)"
-                footer
-              >
-                {{ "post_thread.see_more" | transloco }}
-              </button>
+              <ng-container *ngIf="j === thread.children.length - 1 && subcommentPost.CommentCount" feed-post-footer>
+                <div *ngIf="isLoadingMoreReplies" class="post-thread__see-more-loader">
+                  <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+                </div>
+                <button
+                  *ngIf="!isLoadingMoreReplies"
+                  class="post-thread__see-more-button"
+                  (click)="loadMoreReplies(thread, subcommentPost)"
+                  #seeMoreReplies
+                >
+                  {{ "post_thread.see_more" | transloco }}
+                </button>
+              </ng-container>
             </feed-post>
           </div>
         </div>

--- a/src/app/post-thread-page/post-thread/post-thread.component.scss
+++ b/src/app/post-thread-page/post-thread/post-thread.component.scss
@@ -5,3 +5,7 @@
   background-color: transparent;
   padding-bottom: 16px;
 }
+
+.post-thread__see-more-loader {
+  padding: 12px 30%;
+}

--- a/src/app/post-thread-page/post-thread/post-thread.component.scss
+++ b/src/app/post-thread-page/post-thread/post-thread.component.scss
@@ -1,0 +1,7 @@
+.post-thread__see-more-button {
+  width: 100%;
+  color: var(--link);
+  border: none;
+  background-color: transparent;
+  padding-bottom: 16px;
+}

--- a/src/app/post-thread-page/post-thread/post-thread.component.ts
+++ b/src/app/post-thread-page/post-thread/post-thread.component.ts
@@ -83,7 +83,7 @@ export class PostThreadComponent implements AfterViewInit {
     private toastr: ToastrService,
     private titleService: Title,
     private location: Location,
-    private i18n: TranslocoService
+    private transloco: TranslocoService
   ) {
     // This line forces the component to reload when only a url param changes.  Without this, the UiScroll component
     // behaves strangely and can reuse data from a previous post.
@@ -314,7 +314,7 @@ export class PostThreadComponent implements AfterViewInit {
   }
 
   loadMoreReplies(thread: Thread, subcomment: PostEntryResponse) {
-    const errorMsg = this.i18n.translate("generic_toast_error");
+    const errorMsg = this.transloco.translate("generic_toast_error");
     this.getPost(false, 0, 1, subcomment.PostHashHex)?.subscribe(
       (res) => {
         if (!res || !res.PostFound) {
@@ -329,7 +329,6 @@ export class PostThreadComponent implements AfterViewInit {
         this.threadManager?.addChildrenToThread(thread, res.PostFound);
       },
       (err) => {
-        // TODO: show a toast
         this.toastr.error(errorMsg, undefined, {
           positionClass: "toast-top-center",
           timeOut: 3000,

--- a/src/app/post-thread-page/post-thread/post-thread.component.ts
+++ b/src/app/post-thread-page/post-thread/post-thread.component.ts
@@ -13,6 +13,7 @@ import { Thread, ThreadManager } from "../helpers/thread-manager";
 import * as _ from "lodash";
 import { document } from "ngx-bootstrap/utils";
 import { Subscription } from "rxjs";
+import { TranslocoService } from "@ngneat/transloco";
 
 @Component({
   selector: "post-thread",
@@ -81,7 +82,8 @@ export class PostThreadComponent implements AfterViewInit {
     private backendApi: BackendApiService,
     private toastr: ToastrService,
     private titleService: Title,
-    private location: Location
+    private location: Location,
+    private i18n: TranslocoService
   ) {
     // This line forces the component to reload when only a url param changes.  Without this, the UiScroll component
     // behaves strangely and can reuse data from a previous post.
@@ -312,15 +314,26 @@ export class PostThreadComponent implements AfterViewInit {
   }
 
   loadMoreReplies(thread: Thread, subcomment: PostEntryResponse) {
+    const errorMsg = this.i18n.translate("generic_toast_error");
     this.getPost(false, 0, 1, subcomment.PostHashHex)?.subscribe(
       (res) => {
         if (!res || !res.PostFound) {
-          throw "This should never happen unless there is an api error. Let's show a toast just in case?";
+          // this *should* never happen.
+          this.toastr.error(errorMsg, undefined, {
+            positionClass: "toast-top-center",
+            timeOut: 3000,
+          });
+          return;
         }
+
         this.threadManager?.addChildrenToThread(thread, res.PostFound);
       },
       (err) => {
         // TODO: show a toast
+        this.toastr.error(errorMsg, undefined, {
+          positionClass: "toast-top-center",
+          timeOut: 3000,
+        });
         console.error(err);
       }
     );

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -573,5 +573,8 @@
   "All":"All",
   "Following": "Following",
   "New": "New",
-  "NFT Gallery": "NFT Gallery"
+  "NFT Gallery": "NFT Gallery",
+  "post_thread": {
+    "see_more": "See more replies"
+  }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -576,5 +576,6 @@
   "NFT Gallery": "NFT Gallery",
   "post_thread": {
     "see_more": "See more replies"
-  }
+  },
+  "generic_toast_error": "Something went wrong. Please try again."
 }


### PR DESCRIPTION
We currently cap the thread depth to avoid making to
many recursive calls on the backend when decorating
the comment tree for the thread page.

This adds a "see more" button that will fetch the
subcomments under the last node in a reply thread
if it has more replies to load.

screenshot:
<img width="635" alt="Screen Shot 2022-01-24 at 8 48 30 PM" src="https://user-images.githubusercontent.com/7357287/150913254-dd1f60a0-8ec1-4140-8499-5a6044434fa7.png">

demo:
https://user-images.githubusercontent.com/7357287/150913155-71dcdbf9-def8-4d1c-bb52-e7efb93b37c0.mov

loading state screenshot:
<img width="341" alt="Screen Shot 2022-01-25 at 10 39 22 AM" src="https://user-images.githubusercontent.com/7357287/151039460-7a841e52-95a3-46a5-aaf8-a03fc62e3161.png">
