### PR TITLE
read more rollup for long posts

### DIFF
--- a/src/app/feed/feed-post/feed-post.component.html
+++ b/src/app/feed/feed-post/feed-post.component.html
@@ -278,12 +278,22 @@
             </div>
 
             <!-- Content -->
-            <div
-              class="feed-post__content"
-              [ngClass]="{ 'pb-10px': quotedContent && showQuotedContent }"
-              [innerHTML]="postContent.Body | sanitizeAndAutoLink"
-              queryParamsHandling="merge"
-            ></div>
+            <div class="feed-post__content">
+              <span
+                [ngClass]="{ 'pb-10px': quotedContent && showQuotedContent }"
+                [innerHTML]="postContent.Body | sanitizeAndAutoLink"
+                queryParamsHandling="merge"
+              ></span>
+              <a
+                *ngIf="showReadMoreRollup"
+                [routerLink]="getRouterLink('/' + this.globalVars.RouteNames.POSTS + '/' + postContent.PostHashHex)"
+                queryParamsHandling="merge"
+                class="link--unstyled"
+              >
+                &nbsp;
+                <strong>Read more</strong>
+              </a>
+            </div>
 
             <!-- Media, don't show images on comment posts. -->
             <div

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -49,7 +49,9 @@ export class FeedPostComponent implements OnInit {
       this.postContent = post;
     }
 
-    if (this.postContent.Body.length > GlobalVarsService.MAX_POST_LENGTH) {
+    // We only allow showing long form content on the post detail page. We truncate it everywhere else with
+    // a read more link to the detail.
+    if (!this.router.url.startsWith("/posts/") && this.postContent.Body.length > GlobalVarsService.MAX_POST_LENGTH) {
       // NOTE: We first spread the string into an array since this will account
       // for unicode multi-codepoint characters like emojis. Just using
       // substring will potentially break a string in the middle of a

--- a/src/app/feed/feed-post/feed-post.component.ts
+++ b/src/app/feed/feed-post/feed-post.component.ts
@@ -48,6 +48,20 @@ export class FeedPostComponent implements OnInit {
     } else {
       this.postContent = post;
     }
+
+    if (this.postContent.Body.length > GlobalVarsService.MAX_POST_LENGTH) {
+      // NOTE: We first spread the string into an array since this will account
+      // for unicode multi-codepoint characters like emojis. Just using
+      // substring will potentially break a string in the middle of a
+      // "surrogate-pair" and render something unexpected in its place. This is
+      // still a relatively naive approach, but it should do the right thing in
+      // almost all cases.
+      // https://dmitripavlutin.com/what-every-javascript-developer-should-know-about-unicode/#length-and-surrogate-pairs
+      const chars = [...this.postContent.Body].slice(0, GlobalVarsService.MAX_POST_LENGTH);
+      this.postContent.Body = `${chars.join("")}...`;
+      this.showReadMoreRollup = true;
+    }
+
     setTimeout(()=>{
       this.ref.detectChanges();
     }, 0)
@@ -163,6 +177,7 @@ export class FeedPostComponent implements OnInit {
   nftEntryResponses: NFTEntryResponse[];
   decryptableNFTEntryResponses: NFTEntryResponse[];
   isFollowing: boolean;
+  showReadMoreRollup = false;
 
   unlockableTooltip =
     "This NFT will come with content that's encrypted and only unlockable by the winning bidder. Note that if an NFT is being resold, it is not guaranteed that the new unlockable will be the same original unlockable.";


### PR DESCRIPTION
We want to limit the length of long form content rendered in the feed to the 560 limit we have defined in diamond. 

<img width="611" alt="Screen Shot 2022-01-26 at 4 42 32 PM" src="https://user-images.githubusercontent.com/7357287/151270665-f15cc7d5-3059-4519-9a98-2f33d2986c90.png">
