### PR TITLE
Add Support for piñata IPFS gateways

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -73,7 +73,8 @@ header @html Content-Security-Policy "
     entre-app-media-dev.s3.us-east-2.amazonaws.com
     *.pearl.app
     *.twimg.com
-    cloudflare-ipfs.com;
+    cloudflare-ipfs.com
+    *.mypinata.cloud;
   font-src 'self'
     https://fonts.googleapis.com
     https://fonts.gstatic.com


### PR DESCRIPTION
Add support to host pinned IPFS files via Piñata gateways. These gateways will show IPFS content faster and without rate limits. So we can use IPFS as storage solution for NFTz.me and others as well. Will also greatly improve rendering of existing IPFS NFT projects like spookies and pixelpirates (those have ratelimits now via cloudflare ipfs)