### PR TITLE
Fix gitpod node/npm version (#598)

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,8 @@
+FROM gitpod/workspace-full:latest
+
+RUN bash -c 'NODE_VERSION="14.15.5" \
+    && source $HOME/.nvm/nvm.sh && nvm install $NODE_VERSION \
+    && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION \
+    && npm -g install npm@7'
+
+RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,7 @@
+# Use custom node & npm versions in image
+image:
+  file: .gitpod.Dockerfile
+
 # Commands to start on workspace startup
 tasks:
   - name: open terminial

--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ more.
 # About This Repo
 Documentation for this repo lives on docs.deso.org. Specifically, the following
 docs should give you everything you need to get started:
-* [DeSo Code Walkthrough](https://docs.deso.org/code/walkthrough)
-* [Setting Up Your Dev Environment](https://docs.deso.org/code/dev-setup)
-* [Making Your First Changes](https://docs.deso.org/code/making-your-first-changes)
+
+- [DeSo Code Walkthrough](https://docs.deso.org/code/walkthrough)
+- [Setting Up Your Dev Environment](https://docs.deso.org/code/dev-setup)
+- [Making Your First Changes](https://docs.deso.org/code/making-your-first-changes)
+
+# Node / NPM versions
+
+This frontend works best with Node v14.15.5 and Npm v7. If you cant use these versions, then try `npm install --force`.
 
 # Start Coding
 


### PR DESCRIPTION
See merged [PR on deso frontend](https://github.com/deso-protocol/frontend/pull/598)

@superzordon 

Prior to the April commit - the gitpod button would launch frontend repo fine in gitpod. But since lockfile was switched to v2 - this broke.

This PR fixes that by customising the docker build used by gitpod and installing node 14.15.5 and npm 7.

## Here is the easy gitpod link to test this PR:

1. open PR in gitpod

[GitPod link to test PR](https://gitpod.io/#https://github.com/diamond-app/frontend/pull/207)

2. If needed, login to gitpod

3. Preview window always uses preview domain for the Node. So to login to frontend, you need to set the correct lastLocalNodeV2 to "https://api.tijn.club/" in your browser Local Storage for the gitpod preview URL.