### PR TITLE
add loading state for comment infinite scroller

### DIFF
--- a/src/app/post-thread-page/post-thread/post-thread.component.html
+++ b/src/app/post-thread-page/post-thread/post-thread.component.html
@@ -116,6 +116,10 @@
         </div>
       </div>
     </div>
+    <div *ngIf="isLoadingMoreTopLevelComments" class="p-5 text-center">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+      <p class="text-secondary fs-14px">Loading more comments...</p>
+    </div>
   </div>
   <!-- Bottom spacer for PWA apps-->
   <div *ngIf="globalVars.windowIsPWA() && globalVars.isMobile()" class="mt-20px"></div>

--- a/src/app/post-thread-page/post-thread/post-thread.component.ts
+++ b/src/app/post-thread-page/post-thread/post-thread.component.ts
@@ -26,6 +26,7 @@ export class PostThreadComponent implements AfterViewInit {
   subscriptions = new Subscription();
   threadManager: ThreadManager | undefined;
   isLoadingMoreReplies = false;
+  isLoadingMoreTopLevelComments = false;
   datasource = new Datasource<Thread>({
     get: (index, count, success) => {
       const numThreads = this.threadManager?.threadCount ?? 0;
@@ -36,6 +37,7 @@ export class PostThreadComponent implements AfterViewInit {
         const start = index < 0 ? 0 : index;
         success(this.threadManager?.threads.slice(start, index + count) ?? []);
       } else {
+        this.isLoadingMoreTopLevelComments = true;
         this.getPost(false, index, count)?.subscribe(
           (res) => {
             // If we got more comments, push them onto the list of comments, increase comment count
@@ -46,8 +48,10 @@ export class PostThreadComponent implements AfterViewInit {
               }
               this.threadManager?.addThreads(res.PostFound.Comments);
               success(this.threadManager?.threads.slice(index, index + count) ?? []);
+              this.isLoadingMoreTopLevelComments = false;
             } else {
               // If there are no more comments, we should stop scrolling
+              this.isLoadingMoreTopLevelComments = false;
               this.scrollingDisabled = true;
               success([]);
             }


### PR DESCRIPTION
It currently seems like you can't scroll to all the comments. It actually works fine, but it takes a bit to load the next set of comments so it just feels broken.

Added this loading animation thing:
![Screenshot from 2022-10-13 12-10-26](https://user-images.githubusercontent.com/7357287/195688682-feb99447-972e-45c9-a3b8-7d4bea6664cc.png)
