### PR TITLE
Fix: fixing infinite scrolling on user profile if user has pinned post

### DIFF
--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.html
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.html
@@ -7,9 +7,11 @@
   class="p-15px"
 >
   <div class="d-flex flex-row align-items-center" style="text-align: center">
-    <span *ngIf="profileBelongsToLoggedInUser(); else elseMissingPostBlock">{{ 'creator_profile_posts.create_fipo' | transloco }}</span>
+    <span *ngIf="profileBelongsToLoggedInUser(); else elseMissingPostBlock">
+      {{ "creator_profile_posts.create_fipo" | transloco }}
+    </span>
     <ng-template #elseMissingPostBlock>
-      <span>@{{ profile.Username }} {{ 'creator_profile_posts.on_platform_no_posts' | transloco }}</span>
+      <span>@{{ profile.Username }} {{ "creator_profile_posts.on_platform_no_posts" | transloco }}</span>
     </ng-template>
   </div>
 </div>
@@ -17,7 +19,10 @@
   <div *ngIf="!globalVars.hasUserBlockedCreator(profile.PublicKeyBase58Check)">
     <div #uiScroll *uiScroll="let post of datasource; let index = index">
       <feed-post
-        *ngIf="post.ProfileEntryResponse"
+        *ngIf="
+          post.ProfileEntryResponse &&
+          ((userHasPinnedPost() && index === 0) || post.PostHashHex !== this.profile?.ExtraData?.PinnedPostHashHex)
+        "
         [contentShouldLinkToThread]="true"
         [includePaddingOnPost]="true"
         [post]="post"

--- a/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
+++ b/src/app/creator-profile-page/creator-profile-posts/creator-profile-posts.component.ts
@@ -1,21 +1,10 @@
-import {
-  ChangeDetectorRef,
-  Component, ElementRef,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output, QueryList,
-  ViewChild,
-  ViewChildren
-} from "@angular/core";
+import { ChangeDetectorRef, Component, EventEmitter, Input, Output } from "@angular/core";
 import { BackendApiService, PostEntryResponse, ProfileEntryResponse } from "../../backend-api.service";
 import { GlobalVarsService } from "../../global-vars.service";
-import { ActivatedRoute, Router } from "@angular/router";
-import { Location } from "@angular/common";
+import { ActivatedRoute } from "@angular/router";
 import { IAdapter, IDatasource } from "ngx-ui-scroll";
 import { InfiniteScroller } from "src/app/infinite-scroller";
 import * as _ from "lodash";
-import { FeedPostComponent } from "../../feed/feed-post/feed-post.component";
 
 @Component({
   selector: "creator-profile-posts",
@@ -47,13 +36,12 @@ export class CreatorProfilePostsComponent {
     private globalVars: GlobalVarsService,
     private backendApi: BackendApiService,
     private route: ActivatedRoute,
-    private cdr: ChangeDetectorRef,
-    private router: Router,
-    private location: Location
+    private cdr: ChangeDetectorRef
   ) {}
 
   getPinnedPost(postHashHex: string): Promise<any> {
-    return this.backendApi.GetSinglePost(
+    return this.backendApi
+      .GetSinglePost(
         this.globalVars.localNode,
         postHashHex,
         this.globalVars.loggedInUser?.PublicKeyBase58Check ?? "" /*ReaderPublicKeyBase58Check*/,
@@ -72,7 +60,9 @@ export class CreatorProfilePostsComponent {
     return (
       this.profile.ExtraData &&
       "PinnedPostHashHex" in this.profile.ExtraData &&
-      this.profile.ExtraData["PinnedPostHashHex"] !== undefined && this.profile.ExtraData["PinnedPostHashHex"] !== "")
+      this.profile.ExtraData["PinnedPostHashHex"] !== undefined &&
+      this.profile.ExtraData["PinnedPostHashHex"] !== ""
+    );
   }
 
   isPinnedPost(post: PostEntryResponse) {
@@ -105,9 +95,7 @@ export class CreatorProfilePostsComponent {
       )
       .toPromise()
       .then(async (res) => {
-        const posts: PostEntryResponse[] = _.filter(res.Posts, (post) => {
-          return post.PostHashHex !== this.profile?.ExtraData?.PinnedPostHashHex;
-        });
+        const posts: PostEntryResponse[] = res.Posts;
         if (this.userHasPinnedPost() && page === 0) {
           const pinnedPost = await this.getPinnedPost(this.profile.ExtraData["PinnedPostHashHex"]);
           posts.unshift(pinnedPost.PostFound);
@@ -117,8 +105,10 @@ export class CreatorProfilePostsComponent {
           this.lastPage = page;
         }
 
-        posts.map((post) => (post.ProfileEntryResponse = this.profile));
-        return posts;
+        return posts.map((post) => ({
+          ...post,
+          ProfileEntryResponse: this.profile,
+        }));
       })
       .finally(() => {
         this.loadingFirstPage = false;


### PR DESCRIPTION
Related issue: https://linear.app/deso/issue/DESO-1085/cant-infinite-scroll-through-posts-on-profile-page

**What's been done**:
* Fixed problem with infinite scrolling on user profile feed

**Screenshots**:
<img width="1405" alt="Screenshot 2022-12-06 at 20 49 02" src="https://user-images.githubusercontent.com/10476834/205996732-e22e3bc3-bc96-4809-a88d-48ce544ac520.png">
<img width="1728" alt="Screenshot 2022-12-06 at 20 49 54" src="https://user-images.githubusercontent.com/10476834/205996736-0a4254e9-a16c-4cbd-b9ba-95a2e17f6fd2.png">
