### PR TITLE
bug: two timestamp on mobile UI

### DIFF
--- a/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
+++ b/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
@@ -6,18 +6,6 @@
   container="body"
   style="align-items: center"
 >
-  <div class="d-inline-block d-lg-none fs-12px fc-muted pr-5px">
-    <span
-      *ngIf="!disableTooltip"
-      class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted align-middle"
-      matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-      mat-raised-button
-      #tooltip="matTooltip"
-      [matTooltip]="globalVars.convertTstampToDateTime(postContent.TimestampNanos)"
-    >
-      {{ globalVars.convertTstampToDaysOrHours(postContent.TimestampNanos) }}
-    </span>
-  </div>
   <a class="js-feed-post__dropdown-toggle link--unstyled text-grey9" role="button" dropdownToggle>
     <i class="fas fa-ellipsis-h"></i>
   </a>


### PR DESCRIPTION
### Currently we have two timestamp on mobile screen UI after recent addition of new timestamp on side of the username as in screenshot below ⬇️ 

![issue](https://user-images.githubusercontent.com/85058931/206842780-8f4d0c55-0551-4c2b-af28-b025c0b09843.jpg)

### We have removed the timestamp near to dropdown element and the outcome looks like this in mobile UI ⬇️ 

![solved](https://user-images.githubusercontent.com/85058931/206842831-c15521bd-e28d-4f6f-8150-90fdd8979382.png)
