### PR TITLE
Fix: Transfer NFT btn in mobile version

### DIFF
--- a/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
+++ b/src/app/feed/feed-post-dropdown/feed-post-dropdown.component.html
@@ -6,18 +6,6 @@
   container="body"
   style="align-items: center"
 >
-  <div class="d-inline-block d-lg-none fs-12px fc-muted pr-5px">
-    <span
-      *ngIf="!disableTooltip"
-      class="d-inline-block ml-1 cursor-pointer lh-12px fc-muted align-middle"
-      matTooltipClass="global__mat-tooltip global__mat-tooltip-font-size"
-      mat-raised-button
-      #tooltip="matTooltip"
-      [matTooltip]="globalVars.convertTstampToDateTime(postContent.TimestampNanos)"
-    >
-      {{ globalVars.convertTstampToDaysOrHours(postContent.TimestampNanos) }}
-    </span>
-  </div>
   <a class="js-feed-post__dropdown-toggle link--unstyled text-grey9" role="button" dropdownToggle>
     <i class="fas fa-ellipsis-h"></i>
   </a>

--- a/src/app/transfer-nft/transfer-nft.component.html
+++ b/src/app/transfer-nft/transfer-nft.component.html
@@ -56,9 +56,7 @@
 
       <div
         [ngClass]="{
-          'floating-bottom-bar': globalVars.isMobile(),
-          'mb-15px': !globalVars.isMobile(),
-          'mt-30px': !globalVars.isMobile()
+          'mb-10px': globalVars
         }"
         class="d-flex align-items-center"
       >


### PR DESCRIPTION
## * ISSUE: Not seeing Transfer NFT button in mobile resolution (It is located outside of the modal as from the code)

## Code location: transfer-nft.component.html
 ```
[ngClass]="{ -
          'floating-bottom-bar': globalVars.isMobile(), <br />
          'mb-15px': !globalVars.isMobile(), <br />
          'mt-30px': !globalVars.isMobile() <br />
        }"
```

![problem fig1](https://user-images.githubusercontent.com/85058931/206903348-660deb6c-318c-4700-b22e-f415ed730134.png)

## Finding NFT Transfer btn (not clickable from mobile resolution)

![problem fig2](https://user-images.githubusercontent.com/85058931/206903521-4feeb50b-6fa2-40ea-ae95-ea53292474a4.png)

## Fixing issue by taking Transfer btn just below the search bar like in Desktop/Laptop resolution

![solved](https://user-images.githubusercontent.com/85058931/206903580-3474de9b-e32d-4edc-a27b-2dace0f413c3.png)


P.S. All the screenshots are from mobile resolution and checked on my personal iPhone too. Review needed.

