### PR TITLE
Track query params based on user preferences on the notifications page

### DIFF
--- a/src/app/notifications-page/notifications-filter-menu/notifications-filter-menu.component.ts
+++ b/src/app/notifications-page/notifications-filter-menu/notifications-filter-menu.component.ts
@@ -12,13 +12,14 @@ export class NotificationsFilterMenuComponent implements OnInit {
   @Output() updateSettingsEvent = new EventEmitter();
 
   @Input() filteredOutSetInput: {};
+  @Input() filteredOutOptions: string[]; // all allowed options
   @Input() expandNotificationsInput: boolean;
 
   filteredOutSet: {};
   expandNotifications: boolean;
 
   ngOnInit() {
-    this.filteredOutSet = {...this.filteredOutSetInput};
+    this.filteredOutSet = { ...this.filteredOutSetInput };
     this.expandNotifications = this.expandNotificationsInput;
   }
 
@@ -27,14 +28,7 @@ export class NotificationsFilterMenuComponent implements OnInit {
   }
 
   selectNone() {
-    this.filteredOutSet = {
-      like: true,
-      diamond: true,
-      transfer: true,
-      follow: true,
-      post: true,
-      nft: true,
-    };
+    this.filteredOutSet = this.filteredOutOptions.reduce((acc, key) => ({ ...acc, [key]: true }), {});
   }
 
   allSelected(): boolean {
@@ -59,14 +53,13 @@ export class NotificationsFilterMenuComponent implements OnInit {
   updateSettings() {
     const settings = {
       filteredOutSet: this.filteredOutSet,
-      expandNotifications: this.expandNotifications
-    }
+      expandNotifications: this.expandNotifications,
+    };
     this.updateSettingsEvent.emit(settings);
     this.closeFilter.emit();
   }
 
   updateCompactView() {
-    this.expandNotifications = !this.expandNotifications
+    this.expandNotifications = !this.expandNotifications;
   }
-
 }

--- a/src/app/notifications-page/notifications-list/notifications-list.component.html
+++ b/src/app/notifications-page/notifications-list/notifications-list.component.html
@@ -3,7 +3,7 @@
   class="global__top-bar d-flex justify-content-between align-items-center fs-18px font-weight-bold pl-15px border-bottom w-100"
   style="z-index: 1"
 >
-  <span>{{ 'notifications.list.notifications' | transloco }}</span>
+  <span>{{ "notifications.list.notifications" | transloco }}</span>
   <i-feather
     name="more-horizontal"
     class="feather-medium mr-10px cursor-pointer fs-0px"
@@ -14,6 +14,7 @@
   <notifications-filter-menu
     [filteredOutSetInput]="filteredOutSet"
     [expandNotificationsInput]="expandNotifications"
+    [filteredOutOptions]="filteredOutOptions"
     (closeFilter)="closeFilterMenu()"
     (updateSettingsEvent)="updateSettings($event)"
   ></notifications-filter-menu>
@@ -22,18 +23,15 @@
   <simple-center-loader></simple-center-loader>
 </div>
 <div *ngIf="(!totalItems || totalItems === 0) && !loadingFirstPage" class="d-flex justify-content-center mt-30px">
-  <span>{{ 'notifications.list.no_notifications' | transloco }}</span>
+  <span>{{ "notifications.list.no_notifications" | transloco }}</span>
 </div>
 <div class="notifications__list-container" id="notification-scroller">
-  <div
-    #uiScroll
-    *uiScroll="let item of datasource; let index = index"
-  >
+  <div #uiScroll *uiScroll="let item of datasource; let index = index">
     <div
       class="notifications__list-item"
       [ngClass]="{
         'last-item': index === totalItems - 1,
-        'border-none': (!item.action && !expandNotifications)
+        'border-none': !item.action && !expandNotifications
       }"
     >
       <div class="p-10px cursor-pointer" *ngIf="item.action" [routerLink]="item.link">
@@ -49,7 +47,7 @@
               [routerLink]="['/' + globalVars.RouteNames.USER_PREFIX, item.actor?.Username]"
             >
               <div *ngIf="item.icon" class="notifications__icon">
-                <i-feather name="{{item.icon}}" class="fs-0px {{item.iconClass}}"></i-feather>
+                <i-feather name="{{ item.icon }}" class="fs-0px {{ item.iconClass }}"></i-feather>
               </div>
             </div>
             <div


### PR DESCRIPTION
**What's been done**:
- When user on `/notifications` page we keep track on the selected filtering params and store them in query
- If user selects no filters, we pass `filter=none` to the query
- If no params are provided in the URL, we additionally check saved params in the localStorage
- Reset the params before leaving the page

**Screenshots**:
<img width="1402" alt="Screenshot 2022-12-14 at 14 49 21" src="https://user-images.githubusercontent.com/10476834/207600073-7176b579-c179-42db-8568-081b12f16a29.png">
<img width="982" alt="Screenshot 2022-12-14 at 14 49 45" src="https://user-images.githubusercontent.com/10476834/207600079-70dbd191-6737-40be-ba1d-f4ce8853caf1.png">
