### PR TITLE
Do not close the Quote modal immediately when user presses escape and has some text entered

### DIFF
--- a/src/app/comment-modal/comment-modal.component.ts
+++ b/src/app/comment-modal/comment-modal.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Input } from "@angular/core";
+import { AfterViewInit, Component, HostListener, Input } from "@angular/core";
 import { BsModalRef } from "ngx-bootstrap/modal";
 import { SwalHelper } from "../../lib/helpers/swal-helper";
 import { GlobalVarsService } from "../global-vars.service";
@@ -15,7 +15,16 @@ export class CommentModalComponent implements AfterViewInit {
   @Input() isQuote = false;
 
   warnBeforeClose: boolean = false;
-  constructor(public bsModalRef: BsModalRef, private globalVars: GlobalVarsService, private translocoService: TranslocoService) {}
+
+  @HostListener("document:keydown.escape") onEscPressed() {
+    this.closeModal();
+  }
+
+  constructor(
+    public bsModalRef: BsModalRef,
+    private globalVars: GlobalVarsService,
+    private translocoService: TranslocoService
+  ) {}
 
   ngAfterViewInit() {
     setTimeout(() => {

--- a/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.ts
+++ b/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.ts
@@ -372,6 +372,7 @@ export class FeedPostIconRowComponent {
         class: "modal-dialog-centered",
         initialState,
         ignoreBackdropClick: true,
+        keyboard: false,
       });
     }
   }


### PR DESCRIPTION
**What's been fixed**:

1. When user hits `Esc` on the keyboard and has no text in the input box - we simply close the dialog
2. When user hits `Est` on the keyboard and already has some text entered we show the dialog warning that there are some changes that can be lost

**Screenshots**:

<img width="870" alt="Screenshot 2022-12-26 at 18 15 59" src="https://user-images.githubusercontent.com/10476834/209567020-2130d2ba-daf9-475a-8209-f3d1f678c512.png">
<img width="828" alt="Screenshot 2022-12-26 at 18 16 09" src="https://user-images.githubusercontent.com/10476834/209567025-faa3892e-3fe9-4f12-895b-efa55e7ef9a4.png">
