### PR TITLE
Feature: New view for reactions summary under the post

### DIFF
--- a/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.html
+++ b/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.html
@@ -13,9 +13,11 @@
       </div>
     </ng-container>
 
-    <div class="reactions-summary__toggle-summary text-secondary">
+    <div
+      class="reaction-summary__reaction-item text-secondary"
+      [ngClass]="{ 'reaction-summary__reaction-item-pill': postReactionCounts.Total > 99 }"
+    >
       {{ globalVars.abbreviateNumber(postReactionCounts.Total, 0) }}
-      {{ globalVars.pluralize(postReactionCounts.Total, "reaction") }}
     </div>
   </div>
 

--- a/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.scss
+++ b/src/app/feed/feed-post-icon-row/feed-post-icon-row.component.scss
@@ -7,26 +7,27 @@ $reaction-hover-helper-left-width: 154px;
 
   .reaction-summary__reaction-item {
     background-color: var(--unread);
-    width: 24px;
-    height: 24px;
+    width: 32px;
+    height: 32px;
     border-radius: 50%;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: thin solid var(--link);
+    border: 3px solid var(--background);
     cursor: pointer;
+
+    &:first-child {
+      margin-left: -7px;
+    }
 
     &:not(:first-child) {
-      margin-left: -10px;
+      margin-left: -12px;
     }
-  }
 
-  .reactions-summary__toggle-summary {
-    text-decoration: underline;
-    cursor: pointer;
-
-    &:hover {
-      color: var(--link) !important;
+    &.reaction-summary__reaction-item-pill {
+      width: auto;
+      border-radius: 16px;
+      padding: 0 7px;
     }
   }
 }


### PR DESCRIPTION
**Screenshots**:

<img width="637" alt="Screenshot 2023-02-10 at 20 10 57" src="https://user-images.githubusercontent.com/10476834/218167534-8b0ecaaa-eb39-441e-8506-eea00aba1c75.png">

<img width="727" alt="Screenshot 2023-02-10 at 20 35 58" src="https://user-images.githubusercontent.com/10476834/218170792-a0106497-0f0e-4f89-bdef-af1f6ecc733c.png">
