### PR TITLE
use mergeTxResponse for post and nft transactions

### DIFF
--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -95,7 +95,6 @@ import {
   sendDiamonds,
   setNotificationMetadata,
   submitPost,
-  SubmitTransactionResponse,
   transferCreatorCoin,
   transferNFT,
   updateFollowingStatus,
@@ -550,7 +549,7 @@ export class BackendApiService {
     SenderPublicKeyBase58Check: string,
     RecipientPublicKeyOrUsername: string,
     AmountNanos: number
-  ): Observable<SendDeSoResponse & SubmitTransactionResponse> {
+  ): Observable<SendDeSoResponse> {
     return from(
       sendDeso({
         SenderPublicKeyBase58Check,
@@ -609,7 +608,7 @@ export class BackendApiService {
         BuyNowPriceNanos,
         AdditionalDESORoyaltiesMap,
         AdditionalCoinRoyaltiesMap,
-      })
+      }).then(mergeTxResponse)
     );
   }
 
@@ -631,7 +630,7 @@ export class BackendApiService {
         MinBidAmountNanos,
         IsBuyNow,
         BuyNowPriceNanos,
-      })
+      }).then(mergeTxResponse)
     );
   }
 
@@ -647,7 +646,7 @@ export class BackendApiService {
         NFTPostHashHex,
         SerialNumber,
         BidAmountNanos,
-      })
+      }).then(mergeTxResponse)
     );
   }
 
@@ -657,7 +656,7 @@ export class BackendApiService {
         UpdaterPublicKeyBase58Check,
         NFTPostHashHex,
         SerialNumber,
-      })
+      }).then(mergeTxResponse)
     );
   }
 
@@ -671,7 +670,7 @@ export class BackendApiService {
         UpdaterPublicKeyBase58Check,
         NFTPostHashHex,
         SerialNumber,
-      })
+      }).then(mergeTxResponse)
     );
   }
 
@@ -895,7 +894,7 @@ export class BackendApiService {
         RepostedPostHashHex,
         PostExtraData,
         IsHidden,
-      })
+      }).then(mergeTxResponse)
     );
   }
 
@@ -1298,12 +1297,7 @@ export class BackendApiService {
         DiamondPostHashHex,
         DiamondLevel,
       })
-    ).pipe(
-      map((res) => ({
-        ...res.constructedTransactionResponse,
-        ...res.submittedTransactionResponse,
-      }))
-    );
+    ).pipe(map(mergeTxResponse));
   }
 
   GetDiamondsForPublicKey(PublicKeyBase58Check: string, FetchYouDiamonded: boolean = false): Observable<any> {

--- a/src/app/create-long-post-page/create-long-post/create-long-post.component.ts
+++ b/src/app/create-long-post-page/create-long-post/create-long-post.component.ts
@@ -349,14 +349,14 @@ export class CreateLongPostComponent implements AfterViewInit {
         )
         .toPromise();
 
-      const submittedPostHashHex = postTx.submittedTransactionResponse.PostEntryResponse.PostHashHex;
+      const submittedPostHashHex = postTx.PostEntryResponse.PostHashHex;
 
       // if this is a new post, or the author updates the title of an existing
       // post, update the user's profile with a mapping from postHashHex to url
       // slug
       if (!this.editPostHashHex || !existingSlugMappings[titleSlug]) {
         // first, wait for the submitPost tx to show up to prevent any utxo double spend errors.
-        await waitForTransactionFound(postTx.submittedTransactionResponse.TxnHashHex);
+        await waitForTransactionFound(postTx.TxnHashHex);
 
         const blogSlugMapJSON = JSON.stringify({
           ...existingSlugMappings,

--- a/src/app/feed/feed-create-post/feed-create-post.component.ts
+++ b/src/app/feed/feed-create-post/feed-create-post.component.ts
@@ -385,8 +385,7 @@ export class FeedCreatePostComponent implements OnInit {
         false /*IsHidden*/
       )
       .toPromise()
-      .then((desoJsResponse) => {
-        const response = desoJsResponse.submittedTransactionResponse;
+      .then((response) => {
         this.tracking.log(`post : ${action}`, {
           type: postType,
           hasText: bodyObj.Body.length > 0,


### PR DESCRIPTION
To replicate the old behavior for constructing and submitting transactions in diamond, we need to merge the constructed and submitted response objects together. Most other transactions were already updated to merge the responses, but there were some that were overlooked.