### PR TITLE
Fix: Fixing broken posts width in the feed when install PWA dialog is shown

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -12,6 +12,6 @@
   *ngIf="!globalVars.requestingStorageAccess"
   (touchmove)="preventScroll($event)"
 >
-  <router-outlet *ngIf="!globalVars.loadingInitialAppState"></router-outlet>
   <install-pwa *ngIf="globalVars.isMobile() && !globalVars.windowIsPWA() && globalVars.showInstallPWA"></install-pwa>
+  <router-outlet *ngIf="!globalVars.loadingInitialAppState"></router-outlet>
 </div>

--- a/src/app/install-pwa/install-pwa.component.scss
+++ b/src/app/install-pwa/install-pwa.component.scss
@@ -1,10 +1,6 @@
 $install-pwa-X-padding: 20px;
 $arrow-down-icon-wrapper-size: 50px;
 
-:host {
-  width: auto !important;
-}
-
 .install-pwa {
   background: var(--norm);
   z-index: 3000;


### PR DESCRIPTION
**Root cause**:

There is an important style applied to every last element in `.global-container` that got broken because install PWA was added as the last element. The style looks like this:

```
.global__container > *:last-child {
  width: 100%
}
```

**Solution**:
A simple reordering of router wrapper with install-pwa fixed the issue

**Screenshots**:

<img width="779" alt="Screenshot 2023-04-19 at 15 00 23" src="https://user-images.githubusercontent.com/10476834/233068409-c7296501-12b9-4765-96cf-b1ed09a0f3bc.png">
