### PR TITLE
Add Twitter Embed, plus Fix TikTok Embed Height

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -132,6 +132,10 @@ header @html Content-Security-Policy "
     https://youtube.com
     https://player.vimeo.com
     https://www.tiktok.com
+    https://platform.twitter.com
+    https://twitter.com
+    https://platform.x.com
+    https://x.com
     https://giphy.com
     https://open.spotify.com
     https://embed-standalone.spotify.com

--- a/src/assets/i18n-02-07-23/en.json
+++ b/src/assets/i18n-02-07-23/en.json
@@ -201,7 +201,7 @@
     "multi_post_progress": "Submitting posts:",
     "post": "Post",
     "embed_image": "Link to Arweave image",
-    "embed_video": "Embed Youtube, Vimeo, TikTok, Giphy, Spotify, Mousai, or SoundCloud",
+    "embed_video": "Embed Youtube, Vimeo, TikTok, Twitter, Giphy, Spotify, Mousai, or SoundCloud",
     "quotes": {
       "quote1": "Go ahead, make my day.",
       "quote2": "The stuff that dreams are made of.",

--- a/src/assets/i18n-02-07-23/fr.json
+++ b/src/assets/i18n-02-07-23/fr.json
@@ -200,7 +200,7 @@
       "complete":"Terminé",
       "post": "Message",
       "embed_image": "Lien vers une image Arweave",
-      "embed_video": "Intégrer Youtube, Vimeo, TikTok, Giphy, Spotify ou SoundCloud",
+      "embed_video": "Intégrer Youtube, Vimeo, TikTok, Twitter, Giphy, Spotify ou SoundCloud",
       "quotes": {
         "quote1": "Vas-y, refait ma journée.",
         "quote2": "Les choses dont les rêves sont fait.",

--- a/src/assets/i18n-02-07-23/nl.json
+++ b/src/assets/i18n-02-07-23/nl.json
@@ -196,7 +196,7 @@
     "complete": "Voltooid",
     "post": "Plaats",
     "embed_image": "Voeg een link naar een Arweave afbeelding toe",
-    "embed_video": "Voeg je Youtube, Vimeo, TikTok, Giphy, Spotify of SoundCloud video toe",
+    "embed_video": "Voeg je Youtube, Vimeo, TikTok, Twitter, Giphy, Spotify of SoundCloud video toe",
     "quotes": {
       "quote1": "Het leven is wat je vandaag viert.",
       "quote2": "Geef wat je ontvangt, Ontvang wat je krijgt, Waardeer wat je hebt.",

--- a/src/lib/services/embed-url-parser-service/embed-url-parser-service.spec.ts
+++ b/src/lib/services/embed-url-parser-service/embed-url-parser-service.spec.ts
@@ -69,6 +69,13 @@ describe("EmbedUrlParserService", () => {
 
   const validTikTokEmbedURLs = [`https://www.tiktok.com/embed/v2/${tiktokVideoID}`];
 
+  const twitterPostID = "1819749725568110806";
+  const validTwitterURLs = [
+    `https://twitter.com/teslaownersSV/status/${twitterPostID}`,
+    `https://x.com/teslaownersSV/status/${twitterPostID}`,
+  ];
+  const validTwitterEmbedURLs = [`https://platform.twitter.com/embed/Tweet.html?id=${twitterPostID}`];
+
   const giphyID = "J1ABRhlfvQNwIOiAas";
   const validGiphyURLs = [
     `https://giphy.com/gifs/memecandy-${giphyID}`,
@@ -149,6 +156,7 @@ describe("EmbedUrlParserService", () => {
     "123abc.com/1234556",
     `https://wwwzyoutube.com/embed/${youtubeVideoID}`,
     `https://nottiktok.com/embed/v2/${tiktokShortVideoID}`,
+    `https://notx.com/embed/Tweet.html?id=${twitterPostID}`,
     `https://giphy.com/gifs/abc-def-${giphyID}-;<script></script>`,
     `https://open.notspotify.com/embed/track/${spotifyID}-?;<script/></script>`,
     `https://w.soundcloud.com/player/<script>?url=maliciousscript</script>?hide_related=true&show_comments=false`,
@@ -227,6 +235,22 @@ describe("EmbedUrlParserService", () => {
           expect(EmbedUrlParserService.isValidEmbedURL(constructedEmbedURL)).toBeTruthy();
         }
       );
+    }
+  });
+
+  it("parses twitter URLs from user input correctly and only validates embed urls", () => {
+    for (const link of validTwitterURLs) {
+      expect(EmbedUrlParserService.isTwitterLink(link)).toBeTruthy();
+      const embedURL = EmbedUrlParserService.constructTwitterEmbedURL(new URL(link));
+      expect(embedURL).toEqual(`https://platform.twitter.com/embed/Tweet.html?id=${twitterPostID}`);
+      expect(EmbedUrlParserService.isValidEmbedURL(embedURL)).toBeTruthy();
+      expect(EmbedUrlParserService.isValidEmbedURL(link)).toBeFalsy();
+    }
+    for (const embedLink of validTwitterEmbedURLs) {
+      expect(EmbedUrlParserService.isTwitterLink(embedLink)).toBeTruthy();
+      expect(EmbedUrlParserService.isValidEmbedURL(embedLink)).toBeTruthy();
+      const constructedEmbedURL = EmbedUrlParserService.constructTwitterEmbedURL(new URL(embedLink));
+      expect(EmbedUrlParserService.isValidEmbedURL(constructedEmbedURL)).toBeTruthy();
     }
   });
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2691,7 +2691,7 @@ bs-dropdown-container {
   justify-content: center;
   align-items: center;
   overflow: hidden;
-  max-height: 700px;
+  max-height: 760px;
   border-radius: 6px;
   margin-top: 10px;
   margin-bottom: 5px;


### PR DESCRIPTION
Added Twitter Embed functionality 
e.g. https://twitter.com/teslaownersSV/status/1819749725568110806 
or https://x.com/teslaownersSV/status/1819749725568110806

Twitter Embed IFRAME has been given 500px height - this accommodates shorter tweets without requiring the user to scroll the iframe...but longer tweets will still require internal iframe scrolling. This 500px seemed like a good height trade-off i.e. choosing  between: avoiding scrolling in "most cases" vs introducing a lot of extra white-space when the tweet is short but the IFRAME was hardcoded to something like 700px. ...setting a fixed IFRAME height will never be perfect when the inner content height is unknown.

Please note that Twitter's Tweet.html page contains a HTML tag with style for overflow-y: scroll. Which forces a scrollbar to be visible inside the IFRAME (even if the content height is less than the IFRAME height). This is unavoidable.
`<html dir="ltr" lang="en" style="overflow-y: scroll; overscroll-behavior-y: none;">`

I've also gone ahead and fixed the TikTok Embed height, previously it was given 700px height when posting, but then 315px height when viewing a post (a bug)...the cause of this was isValidTiktokEmbedURL did not match the EmbedVideoURL. So I added an additional check against isTikTokLink to accommodate for both URLs (normal url and embed url). I also updated to 760px height for TikTok embeds as this height more reliably avoids seeing a scrollbar inside the IFRAME. 

